### PR TITLE
[campaign] 캠페인 기능 - 캠페인 생성, 조회, 삭제 #111

### DIFF
--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/common/exception/ErrorCode.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/common/exception/ErrorCode.java
@@ -29,7 +29,12 @@ public enum ErrorCode implements ErrorCodeType {
   COUPON_INVALID_AMOUNT("50008", "유효하지 않은 금액입니다", HttpStatus.BAD_REQUEST),
   COUPON_INVALID_DISCOUNT_RATE("50009", "유효하지 않은 할인율입니다", HttpStatus.BAD_REQUEST),
   DELETED_COUPON_OPERATION_NOT_ALLOWED(
-      "50010", "삭제된 쿠폰은 해당 작업을 수행할 수 없습니다", HttpStatus.BAD_REQUEST);
+      "50010", "삭제된 쿠폰은 해당 작업을 수행할 수 없습니다", HttpStatus.BAD_REQUEST),
+
+  // 캠페인 관련 에러 (51000번대)
+  CAMPAIGN_NOT_FOUND("51001", "캠페인을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+  CAMPAIGN_ALREADY_DELETED("51002", "이미 삭제된 캠페인입니다", HttpStatus.BAD_REQUEST),
+  INVALID_CAMPAIGN_DATE_RANGE("51003", "캠페인 종료일은 시작일보다 늦어야 합니다", HttpStatus.BAD_REQUEST);
 
   private final String code;
   private final String message;

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/application/controller/CampaignCommandController.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/application/controller/CampaignCommandController.java
@@ -1,0 +1,71 @@
+package com.deveagles.be15_deveagles_be.features.campaigns.command.application.controller;
+
+import com.deveagles.be15_deveagles_be.common.dto.ApiResponse;
+import com.deveagles.be15_deveagles_be.features.campaigns.command.application.dto.request.CreateCampaignRequest;
+import com.deveagles.be15_deveagles_be.features.campaigns.command.application.dto.response.CampaignResponse;
+import com.deveagles.be15_deveagles_be.features.campaigns.command.application.service.CampaignCommandService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "캠페인 관리", description = "캠페인 생성, 삭제 API")
+@RestController
+@RequestMapping("/campaigns")
+@RequiredArgsConstructor
+@Validated
+@Slf4j
+public class CampaignCommandController {
+
+  private final CampaignCommandService campaignCommandService;
+
+  @Operation(summary = "캠페인 생성", description = "새로운 캠페인을 생성합니다.")
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "201",
+        description = "캠페인 생성 성공",
+        content = @Content(schema = @Schema(implementation = CampaignResponse.class))),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "400",
+        description = "잘못된 요청 데이터")
+  })
+  @PostMapping
+  public ResponseEntity<ApiResponse<CampaignResponse>> createCampaign(
+      @Parameter(description = "캠페인 생성 정보", required = true) @Valid @RequestBody
+          CreateCampaignRequest request) {
+    log.info("캠페인 생성 요청 - 제목: {}, 매장ID: {}", request.getCampaignTitle(), request.getShopId());
+
+    CampaignResponse response = campaignCommandService.createCampaign(request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+  }
+
+  @Operation(summary = "캠페인 삭제", description = "캠페인을 소프트 삭제합니다.")
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "캠페인 삭제 성공"),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "404",
+        description = "캠페인을 찾을 수 없음"),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "400",
+        description = "이미 삭제된 캠페인")
+  })
+  @DeleteMapping("/{campaignId}")
+  public ResponseEntity<ApiResponse<String>> deleteCampaign(
+      @Parameter(description = "캠페인 ID", required = true) @PathVariable Long campaignId) {
+    log.info("캠페인 삭제 요청 - ID: {}", campaignId);
+
+    campaignCommandService.deleteCampaign(campaignId);
+    return ResponseEntity.ok(ApiResponse.success("캠페인이 성공적으로 삭제되었습니다."));
+  }
+}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/application/dto/request/CreateCampaignRequest.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/application/dto/request/CreateCampaignRequest.java
@@ -1,0 +1,37 @@
+package com.deveagles.be15_deveagles_be.features.campaigns.command.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateCampaignRequest {
+
+  @NotBlank(message = "캠페인 제목은 필수입니다.")
+  @Size(max = 30, message = "캠페인 제목은 30자 이하여야 합니다.")
+  private String campaignTitle;
+
+  @Size(max = 255, message = "설명은 255자 이하여야 합니다.")
+  private String description;
+
+  @NotNull(message = "시작일은 필수입니다.") private LocalDate startDate;
+
+  @NotNull(message = "종료일은 필수입니다.") private LocalDate endDate;
+
+  private LocalDateTime messageSendAt;
+
+  @NotNull(message = "작성자 ID는 필수입니다.") private Long staffId;
+
+  @NotNull(message = "템플릿 ID는 필수입니다.") private Long templateId;
+
+  @NotNull(message = "쿠폰 ID는 필수입니다.") private Long couponId;
+
+  @NotNull(message = "상점 ID는 필수입니다.") private Long shopId;
+}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/application/dto/response/CampaignResponse.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/application/dto/response/CampaignResponse.java
@@ -1,0 +1,46 @@
+package com.deveagles.be15_deveagles_be.features.campaigns.command.application.dto.response;
+
+import com.deveagles.be15_deveagles_be.features.campaigns.command.domain.aggregate.Campaign;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CampaignResponse {
+
+  private Long id;
+  private String campaignTitle;
+  private String description;
+
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private LocalDateTime messageSendAt;
+  private LocalDateTime createdAt;
+
+  private Long staffId;
+  private Long templateId;
+  private Long couponId;
+  private Long shopId;
+
+  public static CampaignResponse from(Campaign campaign) {
+    return CampaignResponse.builder()
+        .id(campaign.getId())
+        .campaignTitle(campaign.getCampaignTitle())
+        .description(campaign.getDescription())
+        .startDate(campaign.getStartDate())
+        .endDate(campaign.getEndDate())
+        .messageSendAt(campaign.getMessageSendAt())
+        .createdAt(campaign.getCreatedAt())
+        .staffId(campaign.getStaffId())
+        .templateId(campaign.getTemplateId())
+        .couponId(campaign.getCouponId())
+        .shopId(campaign.getShopId())
+        .build();
+  }
+}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/application/service/CampaignCommandService.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/application/service/CampaignCommandService.java
@@ -1,0 +1,10 @@
+package com.deveagles.be15_deveagles_be.features.campaigns.command.application.service;
+
+import com.deveagles.be15_deveagles_be.features.campaigns.command.application.dto.request.CreateCampaignRequest;
+import com.deveagles.be15_deveagles_be.features.campaigns.command.application.dto.response.CampaignResponse;
+
+public interface CampaignCommandService {
+  CampaignResponse createCampaign(CreateCampaignRequest request);
+
+  void deleteCampaign(Long campaignId);
+}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/application/service/CampaignCommandServiceImpl.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/application/service/CampaignCommandServiceImpl.java
@@ -1,0 +1,61 @@
+package com.deveagles.be15_deveagles_be.features.campaigns.command.application.service;
+
+import com.deveagles.be15_deveagles_be.common.exception.BusinessException;
+import com.deveagles.be15_deveagles_be.common.exception.ErrorCode;
+import com.deveagles.be15_deveagles_be.features.campaigns.command.application.dto.request.CreateCampaignRequest;
+import com.deveagles.be15_deveagles_be.features.campaigns.command.application.dto.response.CampaignResponse;
+import com.deveagles.be15_deveagles_be.features.campaigns.command.domain.aggregate.Campaign;
+import com.deveagles.be15_deveagles_be.features.campaigns.command.domain.repository.CampaignRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CampaignCommandServiceImpl implements CampaignCommandService {
+
+  private final CampaignRepository campaignRepository;
+
+  @Override
+  public CampaignResponse createCampaign(CreateCampaignRequest request) {
+    validateCampaignDates(request);
+
+    Campaign campaign =
+        Campaign.builder()
+            .campaignTitle(request.getCampaignTitle())
+            .description(request.getDescription())
+            .startDate(request.getStartDate())
+            .endDate(request.getEndDate())
+            .messageSendAt(request.getMessageSendAt())
+            .staffId(request.getStaffId())
+            .templateId(request.getTemplateId())
+            .couponId(request.getCouponId())
+            .shopId(request.getShopId())
+            .build();
+
+    Campaign savedCampaign = campaignRepository.save(campaign);
+    return CampaignResponse.from(savedCampaign);
+  }
+
+  @Override
+  public void deleteCampaign(Long campaignId) {
+    Campaign campaign =
+        campaignRepository
+            .findById(campaignId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.CAMPAIGN_NOT_FOUND));
+
+    if (campaign.isDeleted()) {
+      throw new BusinessException(ErrorCode.CAMPAIGN_ALREADY_DELETED);
+    }
+
+    campaign.softDelete();
+    campaignRepository.save(campaign);
+  }
+
+  private void validateCampaignDates(CreateCampaignRequest request) {
+    if (request.getEndDate().isBefore(request.getStartDate())) {
+      throw new BusinessException(ErrorCode.INVALID_CAMPAIGN_DATE_RANGE);
+    }
+  }
+}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/domain/aggregate/Campaign.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/domain/aggregate/Campaign.java
@@ -1,0 +1,84 @@
+package com.deveagles.be15_deveagles_be.features.campaigns.command.domain.aggregate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "campaign")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Campaign {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "campaign_id")
+  private Long id;
+
+  @Column(name = "campaign_title", nullable = false, length = 30)
+  private String campaignTitle;
+
+  @Column(name = "description", length = 255)
+  private String description;
+
+  @Column(name = "start_date", nullable = false)
+  private LocalDate startDate;
+
+  @Column(name = "end_date", nullable = false)
+  private LocalDate endDate;
+
+  @Column(name = "message_send_at")
+  private LocalDateTime messageSendAt;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
+
+  @Column(name = "staff_id", nullable = false)
+  private Long staffId;
+
+  @Column(name = "template_id", nullable = false)
+  private Long templateId;
+
+  @Column(name = "coupon_id", nullable = false)
+  private Long couponId;
+
+  @Column(name = "shop_id", nullable = false)
+  private Long shopId;
+
+  // Business methods
+  public void softDelete() {
+    this.deletedAt = LocalDateTime.now();
+  }
+
+  public boolean isDeleted() {
+    return this.deletedAt != null;
+  }
+
+  public boolean isActive() {
+    LocalDate now = LocalDate.now();
+    return !isDeleted()
+        && (startDate.isBefore(now) || startDate.isEqual(now))
+        && (endDate.isAfter(now) || endDate.isEqual(now));
+  }
+
+  public boolean canBeSent() {
+    return isActive() && messageSendAt != null && messageSendAt.isBefore(LocalDateTime.now());
+  }
+}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/domain/repository/CampaignRepository.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/domain/repository/CampaignRepository.java
@@ -1,0 +1,12 @@
+package com.deveagles.be15_deveagles_be.features.campaigns.command.domain.repository;
+
+import com.deveagles.be15_deveagles_be.features.campaigns.command.domain.aggregate.Campaign;
+import java.util.Optional;
+
+public interface CampaignRepository {
+  Campaign save(Campaign campaign);
+
+  Optional<Campaign> findById(Long id);
+
+  void delete(Campaign campaign);
+}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/infrastructure/repository/CampaignJpaRepository.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/infrastructure/repository/CampaignJpaRepository.java
@@ -1,0 +1,6 @@
+package com.deveagles.be15_deveagles_be.features.campaigns.command.infrastructure.repository;
+
+import com.deveagles.be15_deveagles_be.features.campaigns.command.domain.aggregate.Campaign;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CampaignJpaRepository extends JpaRepository<Campaign, Long> {}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/infrastructure/repository/CampaignRepositoryImpl.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/command/infrastructure/repository/CampaignRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.deveagles.be15_deveagles_be.features.campaigns.command.infrastructure.repository;
+
+import com.deveagles.be15_deveagles_be.features.campaigns.command.domain.aggregate.Campaign;
+import com.deveagles.be15_deveagles_be.features.campaigns.command.domain.repository.CampaignRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CampaignRepositoryImpl implements CampaignRepository {
+
+  private final CampaignJpaRepository campaignJpaRepository;
+
+  @Override
+  public Campaign save(Campaign campaign) {
+    return campaignJpaRepository.save(campaign);
+  }
+
+  @Override
+  public Optional<Campaign> findById(Long id) {
+    return campaignJpaRepository.findById(id);
+  }
+
+  @Override
+  public void delete(Campaign campaign) {
+    campaignJpaRepository.delete(campaign);
+  }
+}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/query/controller/CampaignQueryController.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/query/controller/CampaignQueryController.java
@@ -1,0 +1,57 @@
+package com.deveagles.be15_deveagles_be.features.campaigns.query.controller;
+
+import com.deveagles.be15_deveagles_be.common.dto.ApiResponse;
+import com.deveagles.be15_deveagles_be.common.dto.PagedResponse;
+import com.deveagles.be15_deveagles_be.common.dto.PagedResult;
+import com.deveagles.be15_deveagles_be.features.campaigns.query.dto.request.CampaignSearchRequest;
+import com.deveagles.be15_deveagles_be.features.campaigns.query.dto.response.CampaignQueryResponse;
+import com.deveagles.be15_deveagles_be.features.campaigns.query.service.CampaignQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "캠페인 조회", description = "캠페인 조회 API")
+@RestController
+@RequestMapping("/campaigns")
+@RequiredArgsConstructor
+@Validated
+@Slf4j
+public class CampaignQueryController {
+
+  private final CampaignQueryService campaignQueryService;
+
+  @Operation(summary = "매장별 캠페인 조회", description = "매장 ID로 캠페인을 페이징 조회합니다. 삭제되지 않은 캠페인만 조회됩니다.")
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "캠페인 조회 성공",
+        content = @Content(schema = @Schema(implementation = PagedResponse.class))),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "400",
+        description = "잘못된 요청 파라미터")
+  })
+  @GetMapping
+  public ResponseEntity<ApiResponse<PagedResponse<CampaignQueryResponse>>> getCampaignsByShop(
+      @Parameter(description = "매장 ID", required = true, example = "1") @RequestParam Long shopId,
+      @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0")
+          int page,
+      @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10")
+          int size) {
+    log.info("매장별 캠페인 조회 요청 - 매장ID: {}, 페이지: {}, 크기: {}", shopId, page, size);
+
+    CampaignSearchRequest request = new CampaignSearchRequest(shopId, page, size);
+    PagedResult<CampaignQueryResponse> pagedResult =
+        campaignQueryService.getCampaignsByShop(request);
+    PagedResponse<CampaignQueryResponse> response = PagedResponse.from(pagedResult);
+
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/query/dto/request/CampaignSearchRequest.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/query/dto/request/CampaignSearchRequest.java
@@ -1,0 +1,21 @@
+package com.deveagles.be15_deveagles_be.features.campaigns.query.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CampaignSearchRequest {
+
+  @NotNull(message = "상점 ID는 필수입니다.") private Long shopId;
+
+  @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.")
+  private int page = 0;
+
+  @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.")
+  private int size = 10;
+}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/query/dto/response/CampaignQueryResponse.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/query/dto/response/CampaignQueryResponse.java
@@ -1,0 +1,46 @@
+package com.deveagles.be15_deveagles_be.features.campaigns.query.dto.response;
+
+import com.deveagles.be15_deveagles_be.features.campaigns.command.domain.aggregate.Campaign;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CampaignQueryResponse {
+
+  private Long id;
+  private String campaignTitle;
+  private String description;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private LocalDateTime messageSendAt;
+  private LocalDateTime createdAt;
+  private Long staffId;
+  private Long templateId;
+  private Long couponId;
+  private Long shopId;
+  private boolean isActive;
+
+  public static CampaignQueryResponse from(Campaign campaign) {
+    return CampaignQueryResponse.builder()
+        .id(campaign.getId())
+        .campaignTitle(campaign.getCampaignTitle())
+        .description(campaign.getDescription())
+        .startDate(campaign.getStartDate())
+        .endDate(campaign.getEndDate())
+        .messageSendAt(campaign.getMessageSendAt())
+        .createdAt(campaign.getCreatedAt())
+        .staffId(campaign.getStaffId())
+        .templateId(campaign.getTemplateId())
+        .couponId(campaign.getCouponId())
+        .shopId(campaign.getShopId())
+        .isActive(campaign.isActive())
+        .build();
+  }
+}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/query/repository/CampaignQueryRepository.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/query/repository/CampaignQueryRepository.java
@@ -1,0 +1,11 @@
+package com.deveagles.be15_deveagles_be.features.campaigns.query.repository;
+
+import com.deveagles.be15_deveagles_be.features.campaigns.command.domain.aggregate.Campaign;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CampaignQueryRepository extends JpaRepository<Campaign, Long> {
+
+  Page<Campaign> findByShopIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long shopId, Pageable pageable);
+}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/query/service/CampaignQueryService.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/query/service/CampaignQueryService.java
@@ -1,0 +1,9 @@
+package com.deveagles.be15_deveagles_be.features.campaigns.query.service;
+
+import com.deveagles.be15_deveagles_be.common.dto.PagedResult;
+import com.deveagles.be15_deveagles_be.features.campaigns.query.dto.request.CampaignSearchRequest;
+import com.deveagles.be15_deveagles_be.features.campaigns.query.dto.response.CampaignQueryResponse;
+
+public interface CampaignQueryService {
+  PagedResult<CampaignQueryResponse> getCampaignsByShop(CampaignSearchRequest request);
+}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/query/service/impl/CampaignQueryServiceImpl.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/campaigns/query/service/impl/CampaignQueryServiceImpl.java
@@ -1,0 +1,35 @@
+package com.deveagles.be15_deveagles_be.features.campaigns.query.service.impl;
+
+import com.deveagles.be15_deveagles_be.common.dto.PagedResult;
+import com.deveagles.be15_deveagles_be.features.campaigns.command.domain.aggregate.Campaign;
+import com.deveagles.be15_deveagles_be.features.campaigns.query.dto.request.CampaignSearchRequest;
+import com.deveagles.be15_deveagles_be.features.campaigns.query.dto.response.CampaignQueryResponse;
+import com.deveagles.be15_deveagles_be.features.campaigns.query.repository.CampaignQueryRepository;
+import com.deveagles.be15_deveagles_be.features.campaigns.query.service.CampaignQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CampaignQueryServiceImpl implements CampaignQueryService {
+
+  private final CampaignQueryRepository campaignQueryRepository;
+
+  @Override
+  public PagedResult<CampaignQueryResponse> getCampaignsByShop(CampaignSearchRequest request) {
+    Pageable pageable = PageRequest.of(request.getPage(), request.getSize());
+
+    Page<Campaign> campaignPage =
+        campaignQueryRepository.findByShopIdAndDeletedAtIsNullOrderByCreatedAtDesc(
+            request.getShopId(), pageable);
+
+    Page<CampaignQueryResponse> responsePage = campaignPage.map(CampaignQueryResponse::from);
+
+    return PagedResult.from(responsePage);
+  }
+}

--- a/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/campaigns/command/application/service/CampaignCommandServiceImplTest.java
+++ b/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/campaigns/command/application/service/CampaignCommandServiceImplTest.java
@@ -1,0 +1,184 @@
+package com.deveagles.be15_deveagles_be.features.campaigns.command.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.deveagles.be15_deveagles_be.common.exception.BusinessException;
+import com.deveagles.be15_deveagles_be.common.exception.ErrorCode;
+import com.deveagles.be15_deveagles_be.features.campaigns.command.application.dto.request.CreateCampaignRequest;
+import com.deveagles.be15_deveagles_be.features.campaigns.command.application.dto.response.CampaignResponse;
+import com.deveagles.be15_deveagles_be.features.campaigns.command.domain.aggregate.Campaign;
+import com.deveagles.be15_deveagles_be.features.campaigns.command.domain.repository.CampaignRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CampaignCommandService 단위 테스트")
+class CampaignCommandServiceImplTest {
+
+  @Mock private CampaignRepository campaignRepository;
+
+  @InjectMocks private CampaignCommandServiceImpl campaignCommandService;
+
+  @Test
+  @DisplayName("유효한 캠페인 생성 요청으로 캠페인이 성공적으로 생성된다")
+  void 유효한_캠페인_생성_요청으로_캠페인이_성공적으로_생성된다() {
+    // Given
+    CreateCampaignRequest request =
+        new CreateCampaignRequest(
+            "새해 이벤트",
+            "새해맞이 특가 이벤트",
+            LocalDate.now().minusDays(5),
+            LocalDate.now().plusDays(25),
+            LocalDateTime.now().minusDays(3),
+            1L,
+            1L,
+            1L,
+            1L);
+
+    Campaign savedCampaign =
+        Campaign.builder()
+            .id(1L)
+            .campaignTitle("새해 이벤트")
+            .description("새해맞이 특가 이벤트")
+            .startDate(LocalDate.now().minusDays(5))
+            .endDate(LocalDate.now().plusDays(25))
+            .messageSendAt(LocalDateTime.now().minusDays(3))
+            .staffId(1L)
+            .templateId(1L)
+            .couponId(1L)
+            .shopId(1L)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+    given(campaignRepository.save(any(Campaign.class))).willReturn(savedCampaign);
+
+    // When
+    CampaignResponse response = campaignCommandService.createCampaign(request);
+
+    // Then
+    assertThat(response).isNotNull();
+    assertThat(response.getId()).isEqualTo(1L);
+    assertThat(response.getCampaignTitle()).isEqualTo("새해 이벤트");
+    assertThat(response.getDescription()).isEqualTo("새해맞이 특가 이벤트");
+    assertThat(response.getStartDate()).isEqualTo(LocalDate.now().minusDays(5));
+    assertThat(response.getEndDate()).isEqualTo(LocalDate.now().plusDays(25));
+    assertThat(response.getShopId()).isEqualTo(1L);
+
+    then(campaignRepository).should(times(1)).save(any(Campaign.class));
+  }
+
+  @Test
+  @DisplayName("종료일이 시작일보다 빠른 경우 예외가 발생한다")
+  void 종료일이_시작일보다_빠른_경우_예외가_발생한다() {
+    // Given
+    CreateCampaignRequest request =
+        new CreateCampaignRequest(
+            "잘못된 기간 캠페인",
+            "잘못된 기간 설정",
+            LocalDate.now().plusDays(10),
+            LocalDate.now().minusDays(5), // 종료일이 시작일보다 빠름
+            LocalDateTime.now().plusDays(1),
+            1L,
+            1L,
+            1L,
+            1L);
+
+    // When & Then
+    assertThatThrownBy(() -> campaignCommandService.createCampaign(request))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_CAMPAIGN_DATE_RANGE);
+
+    then(campaignRepository).should(never()).save(any(Campaign.class));
+  }
+
+  @Test
+  @DisplayName("존재하는 캠페인 ID로 캠페인이 성공적으로 삭제된다")
+  void 존재하는_캠페인_ID로_캠페인이_성공적으로_삭제된다() {
+    // Given
+    Long campaignId = 1L;
+    Campaign campaign =
+        Campaign.builder()
+            .id(campaignId)
+            .campaignTitle("삭제할 캠페인")
+            .description("삭제할 캠페인 설명")
+            .startDate(LocalDate.now().minusDays(5))
+            .endDate(LocalDate.now().plusDays(25))
+            .staffId(1L)
+            .templateId(1L)
+            .couponId(1L)
+            .shopId(1L)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+    given(campaignRepository.findById(campaignId)).willReturn(Optional.of(campaign));
+    given(campaignRepository.save(any(Campaign.class))).willReturn(campaign);
+
+    // When
+    campaignCommandService.deleteCampaign(campaignId);
+
+    // Then
+    assertThat(campaign.isDeleted()).isTrue();
+    then(campaignRepository).should(times(1)).findById(campaignId);
+    then(campaignRepository).should(times(1)).save(campaign);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 캠페인 ID로 삭제 시 예외가 발생한다")
+  void 존재하지_않는_캠페인_ID로_삭제_시_예외가_발생한다() {
+    // Given
+    Long nonExistentCampaignId = 999L;
+    given(campaignRepository.findById(nonExistentCampaignId)).willReturn(Optional.empty());
+
+    // When & Then
+    assertThatThrownBy(() -> campaignCommandService.deleteCampaign(nonExistentCampaignId))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CAMPAIGN_NOT_FOUND);
+
+    then(campaignRepository).should(times(1)).findById(nonExistentCampaignId);
+    then(campaignRepository).should(never()).save(any(Campaign.class));
+  }
+
+  @Test
+  @DisplayName("이미 삭제된 캠페인을 다시 삭제 시 예외가 발생한다")
+  void 이미_삭제된_캠페인을_다시_삭제_시_예외가_발생한다() {
+    // Given
+    Long campaignId = 1L;
+    Campaign deletedCampaign =
+        Campaign.builder()
+            .id(campaignId)
+            .campaignTitle("이미 삭제된 캠페인")
+            .description("이미 삭제된 캠페인 설명")
+            .startDate(LocalDate.now().minusDays(5))
+            .endDate(LocalDate.now().plusDays(25))
+            .staffId(1L)
+            .templateId(1L)
+            .couponId(1L)
+            .shopId(1L)
+            .createdAt(LocalDateTime.now())
+            .deletedAt(LocalDateTime.now())
+            .build();
+
+    given(campaignRepository.findById(campaignId)).willReturn(Optional.of(deletedCampaign));
+
+    // When & Then
+    assertThatThrownBy(() -> campaignCommandService.deleteCampaign(campaignId))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CAMPAIGN_ALREADY_DELETED);
+
+    then(campaignRepository).should(times(1)).findById(campaignId);
+    then(campaignRepository).should(never()).save(any(Campaign.class));
+  }
+}

--- a/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/campaigns/query/service/impl/CampaignQueryServiceImplTest.java
+++ b/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/campaigns/query/service/impl/CampaignQueryServiceImplTest.java
@@ -1,0 +1,232 @@
+package com.deveagles.be15_deveagles_be.features.campaigns.query.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.deveagles.be15_deveagles_be.common.dto.PagedResult;
+import com.deveagles.be15_deveagles_be.features.campaigns.command.domain.aggregate.Campaign;
+import com.deveagles.be15_deveagles_be.features.campaigns.query.dto.request.CampaignSearchRequest;
+import com.deveagles.be15_deveagles_be.features.campaigns.query.dto.response.CampaignQueryResponse;
+import com.deveagles.be15_deveagles_be.features.campaigns.query.repository.CampaignQueryRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CampaignQueryService 단위 테스트")
+class CampaignQueryServiceImplTest {
+
+  @Mock private CampaignQueryRepository campaignQueryRepository;
+
+  @InjectMocks private CampaignQueryServiceImpl campaignQueryService;
+
+  @Test
+  @DisplayName("매장 ID로 캠페인 목록을 성공적으로 조회한다")
+  void 매장_ID로_캠페인_목록을_성공적으로_조회한다() {
+    // Given
+    Long shopId = 1L;
+    CampaignSearchRequest request = new CampaignSearchRequest(shopId, 0, 10);
+
+    Campaign campaign1 =
+        Campaign.builder()
+            .id(1L)
+            .campaignTitle("첫 번째 캠페인")
+            .description("첫 번째 캠페인 설명")
+            .startDate(LocalDate.now().minusDays(10))
+            .endDate(LocalDate.now().plusDays(10))
+            .messageSendAt(LocalDateTime.now().minusDays(5))
+            .staffId(1L)
+            .templateId(1L)
+            .couponId(1L)
+            .shopId(shopId)
+            .createdAt(LocalDateTime.now().minusDays(15))
+            .build();
+
+    Campaign campaign2 =
+        Campaign.builder()
+            .id(2L)
+            .campaignTitle("두 번째 캠페인")
+            .description("두 번째 캠페인 설명")
+            .startDate(LocalDate.now().minusDays(20))
+            .endDate(LocalDate.now().plusDays(20))
+            .messageSendAt(LocalDateTime.now().minusDays(10))
+            .staffId(1L)
+            .templateId(2L)
+            .couponId(2L)
+            .shopId(shopId)
+            .createdAt(LocalDateTime.now().minusDays(25))
+            .build();
+
+    List<Campaign> campaigns = Arrays.asList(campaign1, campaign2);
+    Page<Campaign> campaignPage = new PageImpl<>(campaigns, PageRequest.of(0, 10), 2);
+
+    given(
+            campaignQueryRepository.findByShopIdAndDeletedAtIsNullOrderByCreatedAtDesc(
+                eq(shopId), any(Pageable.class)))
+        .willReturn(campaignPage);
+
+    // When
+    PagedResult<CampaignQueryResponse> result = campaignQueryService.getCampaignsByShop(request);
+
+    // Then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(2);
+    assertThat(result.getPagination().getTotalItems()).isEqualTo(2);
+    assertThat(result.getPagination().getTotalPages()).isEqualTo(1);
+    assertThat(result.getPagination().getCurrentPage()).isEqualTo(0);
+
+    // 첫 번째 캠페인 검증
+    CampaignQueryResponse firstResponse = result.getContent().get(0);
+    assertThat(firstResponse.getId()).isEqualTo(1L);
+    assertThat(firstResponse.getCampaignTitle()).isEqualTo("첫 번째 캠페인");
+    assertThat(firstResponse.getDescription()).isEqualTo("첫 번째 캠페인 설명");
+    assertThat(firstResponse.getShopId()).isEqualTo(shopId);
+    assertThat(firstResponse.isActive()).isTrue(); // 현재 날짜 기준으로 활성 상태
+
+    // 두 번째 캠페인 검증
+    CampaignQueryResponse secondResponse = result.getContent().get(1);
+    assertThat(secondResponse.getId()).isEqualTo(2L);
+    assertThat(secondResponse.getCampaignTitle()).isEqualTo("두 번째 캠페인");
+    assertThat(secondResponse.getDescription()).isEqualTo("두 번째 캠페인 설명");
+    assertThat(secondResponse.getShopId()).isEqualTo(shopId);
+
+    then(campaignQueryRepository)
+        .should(times(1))
+        .findByShopIdAndDeletedAtIsNullOrderByCreatedAtDesc(eq(shopId), any(Pageable.class));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 매장 ID로 조회하면 빈 페이지를 반환한다")
+  void 존재하지_않는_매장_ID로_조회하면_빈_페이지를_반환한다() {
+    // Given
+    Long nonExistentShopId = 999L;
+    CampaignSearchRequest request = new CampaignSearchRequest(nonExistentShopId, 0, 10);
+
+    Page<Campaign> emptyCampaignPage = new PageImpl<>(List.of(), PageRequest.of(0, 10), 0);
+
+    given(
+            campaignQueryRepository.findByShopIdAndDeletedAtIsNullOrderByCreatedAtDesc(
+                eq(nonExistentShopId), any(Pageable.class)))
+        .willReturn(emptyCampaignPage);
+
+    // When
+    PagedResult<CampaignQueryResponse> result = campaignQueryService.getCampaignsByShop(request);
+
+    // Then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).isEmpty();
+    assertThat(result.getPagination().getTotalItems()).isEqualTo(0);
+    assertThat(result.getPagination().getTotalPages()).isEqualTo(0);
+    assertThat(result.getPagination().getCurrentPage()).isEqualTo(0);
+
+    then(campaignQueryRepository)
+        .should(times(1))
+        .findByShopIdAndDeletedAtIsNullOrderByCreatedAtDesc(
+            eq(nonExistentShopId), any(Pageable.class));
+  }
+
+  @Test
+  @DisplayName("페이징 파라미터가 올바르게 적용된다")
+  void 페이징_파라미터가_올바르게_적용된다() {
+    // Given
+    Long shopId = 1L;
+    int page = 1;
+    int size = 5;
+    CampaignSearchRequest request = new CampaignSearchRequest(shopId, page, size);
+
+    Campaign campaign =
+        Campaign.builder()
+            .id(1L)
+            .campaignTitle("페이징 테스트 캠페인")
+            .description("페이징 테스트 설명")
+            .startDate(LocalDate.now().minusDays(5))
+            .endDate(LocalDate.now().plusDays(5))
+            .staffId(1L)
+            .templateId(1L)
+            .couponId(1L)
+            .shopId(shopId)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+    List<Campaign> campaigns = List.of(campaign);
+    Page<Campaign> campaignPage = new PageImpl<>(campaigns, PageRequest.of(page, size), 10);
+
+    given(
+            campaignQueryRepository.findByShopIdAndDeletedAtIsNullOrderByCreatedAtDesc(
+                eq(shopId), any(Pageable.class)))
+        .willReturn(campaignPage);
+
+    // When
+    PagedResult<CampaignQueryResponse> result = campaignQueryService.getCampaignsByShop(request);
+
+    // Then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getPagination().getTotalItems()).isEqualTo(10);
+    assertThat(result.getPagination().getTotalPages()).isEqualTo(2);
+    assertThat(result.getPagination().getCurrentPage()).isEqualTo(page);
+
+    then(campaignQueryRepository)
+        .should(times(1))
+        .findByShopIdAndDeletedAtIsNullOrderByCreatedAtDesc(eq(shopId), any(Pageable.class));
+  }
+
+  @Test
+  @DisplayName("삭제된 캠페인은 조회되지 않는다")
+  void 삭제된_캠페인은_조회되지_않는다() {
+    // Given
+    Long shopId = 1L;
+    CampaignSearchRequest request = new CampaignSearchRequest(shopId, 0, 10);
+
+    // 삭제되지 않은 캠페인만 조회되도록 Mock 설정
+    Campaign activeCampaign =
+        Campaign.builder()
+            .id(1L)
+            .campaignTitle("활성 캠페인")
+            .description("활성 캠페인 설명")
+            .startDate(LocalDate.now().minusDays(5))
+            .endDate(LocalDate.now().plusDays(5))
+            .staffId(1L)
+            .templateId(1L)
+            .couponId(1L)
+            .shopId(shopId)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+    List<Campaign> campaigns = List.of(activeCampaign);
+    Page<Campaign> campaignPage = new PageImpl<>(campaigns, PageRequest.of(0, 10), 1);
+
+    given(
+            campaignQueryRepository.findByShopIdAndDeletedAtIsNullOrderByCreatedAtDesc(
+                eq(shopId), any(Pageable.class)))
+        .willReturn(campaignPage);
+
+    // When
+    PagedResult<CampaignQueryResponse> result = campaignQueryService.getCampaignsByShop(request);
+
+    // Then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().get(0).getId()).isEqualTo(1L);
+    assertThat(result.getContent().get(0).getCampaignTitle()).isEqualTo("활성 캠페인");
+
+    then(campaignQueryRepository)
+        .should(times(1))
+        .findByShopIdAndDeletedAtIsNullOrderByCreatedAtDesc(eq(shopId), any(Pageable.class));
+  }
+}

--- a/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/coupons/application/command/CouponCommandServiceImplTest.java
+++ b/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/coupons/application/command/CouponCommandServiceImplTest.java
@@ -1,4 +1,4 @@
-package com.deveagles.be15_deveagles_be.features.coupons.service;
+package com.deveagles.be15_deveagles_be.features.coupons.application.command;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -10,8 +10,6 @@ import static org.mockito.Mockito.times;
 
 import com.deveagles.be15_deveagles_be.common.exception.BusinessException;
 import com.deveagles.be15_deveagles_be.common.exception.ErrorCode;
-import com.deveagles.be15_deveagles_be.features.coupons.application.command.CouponCommandServiceImpl;
-import com.deveagles.be15_deveagles_be.features.coupons.application.command.CreateCouponRequest;
 import com.deveagles.be15_deveagles_be.features.coupons.common.CouponDto;
 import com.deveagles.be15_deveagles_be.features.coupons.domain.entity.Coupon;
 import com.deveagles.be15_deveagles_be.features.coupons.domain.service.CouponCodeGenerator;
@@ -204,6 +202,8 @@ class CouponCommandServiceImplTest {
 
     // Then
     assertThat(result).isNotNull();
+    assertThat(result.getIsActive()).isFalse(); // 비활성화됨
+
     then(couponJpaRepository).should(times(1)).findById(1L);
     then(couponJpaRepository).should(times(1)).save(any(Coupon.class));
   }
@@ -234,6 +234,8 @@ class CouponCommandServiceImplTest {
 
     // Then
     assertThat(result).isNotNull();
+    assertThat(result.getIsActive()).isTrue(); // 활성화됨
+
     then(couponJpaRepository).should(times(1)).findById(1L);
     then(couponJpaRepository).should(times(1)).save(any(Coupon.class));
   }

--- a/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/coupons/application/query/CouponSearchQueryServiceImplTest.java
+++ b/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/coupons/application/query/CouponSearchQueryServiceImplTest.java
@@ -1,4 +1,4 @@
-package com.deveagles.be15_deveagles_be.features.coupons.service;
+package com.deveagles.be15_deveagles_be.features.coupons.application.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -8,8 +8,6 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
 import com.deveagles.be15_deveagles_be.common.dto.PagedResult;
-import com.deveagles.be15_deveagles_be.features.coupons.application.query.CouponQueryServiceImpl;
-import com.deveagles.be15_deveagles_be.features.coupons.application.query.CouponSearchQuery;
 import com.deveagles.be15_deveagles_be.features.coupons.domain.entity.Coupon;
 import com.deveagles.be15_deveagles_be.features.coupons.domain.repository.CouponQueryRepository;
 import com.deveagles.be15_deveagles_be.features.coupons.infrastructure.repository.CouponJpaRepository;
@@ -199,11 +197,8 @@ class CouponSearchQueryServiceImplTest {
     PagedResult<CouponResponse> result = couponQueryService.searchCoupons(query);
 
     // Then
-    assertThat(result).isNotNull();
     assertThat(result.getContent()).hasSize(2);
     assertThat(result.getPagination().getTotalItems()).isEqualTo(2);
-    assertThat(result.getPagination().getTotalPages()).isEqualTo(1);
-    assertThat(result.getPagination().getCurrentPage()).isEqualTo(0);
 
     then(couponQueryRepository).should(times(1)).searchCoupons(eq(query), any(Pageable.class));
   }
@@ -221,8 +216,9 @@ class CouponSearchQueryServiceImplTest {
             .sortDirection("desc")
             .build();
 
+    List<Coupon> activeCoupons = Arrays.asList(activeCoupon);
     Pageable pageable = PageRequest.of(0, 10);
-    Page<Coupon> couponPage = new PageImpl<>(Arrays.asList(activeCoupon), pageable, 1);
+    Page<Coupon> couponPage = new PageImpl<>(activeCoupons, pageable, activeCoupons.size());
 
     given(couponQueryRepository.searchCoupons(eq(query), any(Pageable.class)))
         .willReturn(couponPage);
@@ -231,7 +227,6 @@ class CouponSearchQueryServiceImplTest {
     PagedResult<CouponResponse> result = couponQueryService.searchCoupons(query);
 
     // Then
-    assertThat(result).isNotNull();
     assertThat(result.getContent()).hasSize(1);
     assertThat(result.getContent().get(0).getIsActive()).isTrue();
 
@@ -251,8 +246,9 @@ class CouponSearchQueryServiceImplTest {
             .sortDirection("desc")
             .build();
 
+    List<Coupon> shopCoupons = Arrays.asList(activeCoupon);
     Pageable pageable = PageRequest.of(0, 10);
-    Page<Coupon> couponPage = new PageImpl<>(Arrays.asList(activeCoupon), pageable, 1);
+    Page<Coupon> couponPage = new PageImpl<>(shopCoupons, pageable, shopCoupons.size());
 
     given(couponQueryRepository.searchCoupons(eq(query), any(Pageable.class)))
         .willReturn(couponPage);
@@ -261,7 +257,6 @@ class CouponSearchQueryServiceImplTest {
     PagedResult<CouponResponse> result = couponQueryService.searchCoupons(query);
 
     // Then
-    assertThat(result).isNotNull();
     assertThat(result.getContent()).hasSize(1);
     assertThat(result.getContent().get(0).getShopId()).isEqualTo(1L);
 
@@ -281,8 +276,9 @@ class CouponSearchQueryServiceImplTest {
             .sortDirection("desc")
             .build();
 
+    List<Coupon> itemCoupons = Arrays.asList(activeCoupon);
     Pageable pageable = PageRequest.of(0, 10);
-    Page<Coupon> couponPage = new PageImpl<>(Arrays.asList(activeCoupon), pageable, 1);
+    Page<Coupon> couponPage = new PageImpl<>(itemCoupons, pageable, itemCoupons.size());
 
     given(couponQueryRepository.searchCoupons(eq(query), any(Pageable.class)))
         .willReturn(couponPage);
@@ -291,7 +287,6 @@ class CouponSearchQueryServiceImplTest {
     PagedResult<CouponResponse> result = couponQueryService.searchCoupons(query);
 
     // Then
-    assertThat(result).isNotNull();
     assertThat(result.getContent()).hasSize(1);
     assertThat(result.getContent().get(0).getPrimaryItemId()).isEqualTo(100L);
 
@@ -312,16 +307,15 @@ class CouponSearchQueryServiceImplTest {
             .build();
 
     Pageable pageable = PageRequest.of(0, 10);
-    Page<Coupon> couponPage = new PageImpl<>(Arrays.asList(), pageable, 0);
+    Page<Coupon> emptyPage = new PageImpl<>(Arrays.asList(), pageable, 0);
 
     given(couponQueryRepository.searchCoupons(eq(query), any(Pageable.class)))
-        .willReturn(couponPage);
+        .willReturn(emptyPage);
 
     // When
     PagedResult<CouponResponse> result = couponQueryService.searchCoupons(query);
 
     // Then
-    assertThat(result).isNotNull();
     assertThat(result.getContent()).isEmpty();
     assertThat(result.getPagination().getTotalItems()).isEqualTo(0);
 

--- a/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/coupons/application/validation/CouponApplicationServiceTest.java
+++ b/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/coupons/application/validation/CouponApplicationServiceTest.java
@@ -1,4 +1,4 @@
-package com.deveagles.be15_deveagles_be.features.coupons.service;
+package com.deveagles.be15_deveagles_be.features.coupons.application.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -7,8 +7,6 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
 import com.deveagles.be15_deveagles_be.common.exception.BusinessException;
-import com.deveagles.be15_deveagles_be.features.coupons.application.validation.CouponApplicationService;
-import com.deveagles.be15_deveagles_be.features.coupons.application.validation.CouponValidationService;
 import com.deveagles.be15_deveagles_be.features.coupons.common.CouponResponseFactory;
 import com.deveagles.be15_deveagles_be.features.coupons.domain.entity.Coupon;
 import com.deveagles.be15_deveagles_be.features.coupons.domain.vo.DiscountResult;

--- a/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/coupons/domain/service/CouponDiscountCalculatorTest.java
+++ b/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/coupons/domain/service/CouponDiscountCalculatorTest.java
@@ -1,11 +1,10 @@
-package com.deveagles.be15_deveagles_be.features.coupons.service;
+package com.deveagles.be15_deveagles_be.features.coupons.domain.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.deveagles.be15_deveagles_be.common.exception.BusinessException;
 import com.deveagles.be15_deveagles_be.features.coupons.domain.entity.Coupon;
-import com.deveagles.be15_deveagles_be.features.coupons.domain.service.CouponDiscountCalculator;
 import com.deveagles.be15_deveagles_be.features.coupons.domain.vo.DiscountResult;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -201,6 +200,37 @@ class CouponDiscountCalculatorTest {
     assertThat(result.getDiscountRate()).isEqualTo(0);
     assertThat(result.getDiscountAmount()).isEqualTo(0);
     assertThat(result.getFinalAmount()).isEqualTo(10000);
+    assertThat(result.isValid()).isTrue();
+  }
+
+  @Test
+  @DisplayName("할인 계산 성공 - 100% 할인")
+  void calculateDiscount_100퍼센트할인_성공() {
+    // Given
+    Coupon fullDiscountCoupon =
+        Coupon.builder()
+            .id(1L)
+            .couponCode("CP241201ABCD1234")
+            .couponTitle("무료 쿠폰")
+            .shopId(1L)
+            .primaryItemId(100L)
+            .discountRate(100)
+            .expirationDate(LocalDate.now().plusDays(30))
+            .isActive(true)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+    Integer originalAmount = 10000;
+
+    // When
+    DiscountResult result =
+        couponDiscountCalculator.calculateDiscount(fullDiscountCoupon, originalAmount);
+
+    // Then
+    assertThat(result.getOriginalAmount()).isEqualTo(10000);
+    assertThat(result.getDiscountRate()).isEqualTo(100);
+    assertThat(result.getDiscountAmount()).isEqualTo(10000);
+    assertThat(result.getFinalAmount()).isEqualTo(0);
     assertThat(result.isValid()).isTrue();
   }
 }


### PR DESCRIPTION
### 개발 영역

Backend

### 📋 기능 설명

캠페인 기능 구현
- 캠페인 생성
- 매장 ID로 조회
- 삭제

### ✅ 개발 체크리스트

- [x] 요구사항 분석 완료
- [x] 구현 완료
- [x] 단위 테스트 작성
- [x] 문서 업데이트

## 🔍 이슈 체크리스트 상태
⚠️ **0/4 완료** (미완료 항목 있음)


## 🔗 관련 이슈
Closes #111

---

## 📋 비고

<!-- PR에 관련하여 하고 싶은 말이 있다면 아래에 남겨주세요.-->

<!-- 이슈 번호를 PR 타이틀에 포함하면 (#123) 해당 이슈의 내용, 체크리스트 상태, Closes 키워드가 자동으로 여기에 복사됩니다 -->
<!-- 이슈 내용, 체크리스트 상태, 관련 이슈 정보가 자동으로 여기에 추가됩니다 -->
