### PR TITLE
[schedules] 매장 생성 시 예약 설정 추가 #238

### DIFF
--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/shops/command/application/service/ShopCommandServiceImpl.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/shops/command/application/service/ShopCommandServiceImpl.java
@@ -31,10 +31,8 @@ public class ShopCommandServiceImpl implements ShopCommandService {
             .shopDescription(request.description())
             .build();
 
-    // 1. 먼저 Shop 저장
     Shop savedShop = shopRepository.save(shop);
 
-    // 2. 저장된 shop의 ID를 이용해 예약 설정 초기화
     reservationSettingInitializer.initDefault(savedShop.getShopId());
 
     return savedShop;

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/shops/command/application/service/ShopCommandServiceImpl.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/shops/command/application/service/ShopCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package com.deveagles.be15_deveagles_be.features.shops.command.application.service;
 
+import com.deveagles.be15_deveagles_be.features.schedules.command.application.service.ReservationSettingInitializer;
 import com.deveagles.be15_deveagles_be.features.shops.command.application.dto.request.ShopCreateRequest;
 import com.deveagles.be15_deveagles_be.features.shops.command.application.dto.request.ValidBizNumberRequest;
 import com.deveagles.be15_deveagles_be.features.shops.command.domain.aggregate.Shop;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 public class ShopCommandServiceImpl implements ShopCommandService {
 
   private final ShopRepository shopRepository;
+  private final ReservationSettingInitializer reservationSettingInitializer;
 
   @Override
   public Shop shopRegist(ShopCreateRequest request) {
@@ -29,7 +31,13 @@ public class ShopCommandServiceImpl implements ShopCommandService {
             .shopDescription(request.description())
             .build();
 
-    return shopRepository.save(shop);
+    // 1. 먼저 Shop 저장
+    Shop savedShop = shopRepository.save(shop);
+
+    // 2. 저장된 shop의 ID를 이용해 예약 설정 초기화
+    reservationSettingInitializer.initDefault(savedShop.getShopId());
+
+    return savedShop;
   }
 
   @Override

--- a/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/shops/command/application/ShopCommandServiceImplTest.java
+++ b/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/shops/command/application/ShopCommandServiceImplTest.java
@@ -2,6 +2,7 @@ package com.deveagles.be15_deveagles_be.features.shops.command.application;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.deveagles.be15_deveagles_be.features.schedules.command.application.service.ReservationSettingInitializer;
 import com.deveagles.be15_deveagles_be.features.shops.command.application.dto.request.ShopCreateRequest;
 import com.deveagles.be15_deveagles_be.features.shops.command.application.dto.request.ValidBizNumberRequest;
 import com.deveagles.be15_deveagles_be.features.shops.command.application.service.ShopCommandServiceImpl;
@@ -22,15 +23,17 @@ public class ShopCommandServiceImplTest {
 
   @Mock private ShopRepository shopRepository;
 
+  @Mock private ReservationSettingInitializer reservationSettingInitializer;
+
   private ShopCommandServiceImpl service;
 
   @BeforeEach
   void setUp() {
-    service = new ShopCommandServiceImpl(shopRepository);
+    service = new ShopCommandServiceImpl(shopRepository, reservationSettingInitializer);
   }
 
   @Test
-  @DisplayName("shopRegist: 신규 매장 등록이 정상적으로 수행된다")
+  @DisplayName("shopRegist: 신규 매장 등록 시 예약 설정도 초기화된다")
   void shopRegist_정상_등록_테스트() {
     // given
     ShopCreateRequest request =
@@ -46,6 +49,7 @@ public class ShopCommandServiceImplTest {
 
     Shop expectedShop =
         Shop.builder()
+            .shopId(1L)
             .shopName("디브이헤어")
             .address("서울특별시 강남구 테헤란로")
             .detailAddress("101호")
@@ -64,6 +68,9 @@ public class ShopCommandServiceImplTest {
     assertEquals("디브이헤어", result.getShopName());
     assertEquals("1234567890", result.getBusinessNumber());
     assertEquals("프리미엄 헤어샵", result.getShopDescription());
+
+    // 예약 설정 초기화가 호출되었는지 검증
+    Mockito.verify(reservationSettingInitializer).initDefault(1L);
   }
 
   @Test
@@ -102,7 +109,6 @@ public class ShopCommandServiceImplTest {
   void patchOwnerId_테스트() {
     // given
     Shop shop = Shop.builder().shopName("디브이헤어").build();
-
     Long ownerId = 999L;
 
     // when


### PR DESCRIPTION
### 개발 영역

Backend

### 📋 기능 설명

매장 생성 시 자동으로 예약 설정 추가

### ✅ 개발 체크리스트

- [x] 요구사항 분석 완료
- [x] 구현 완료
- [x] 단위 테스트 작성
- [x] 문서 업데이트

## 🔍 이슈 체크리스트 상태
✅ **4/4 완료** (모든 항목 완료!)


## 🔗 관련 이슈
Closes #238

---

## 📋 비고

<!-- PR에 관련하여 하고 싶은 말이 있다면 아래에 남겨주세요.-->

<!-- 이슈 번호를 PR 타이틀에 포함하면 (#123) 해당 이슈의 내용, 체크리스트 상태, Closes 키워드가 자동으로 여기에 복사됩니다 -->
<!-- 이슈 내용, 체크리스트 상태, 관련 이슈 정보가 자동으로 여기에 추가됩니다 -->
