### PR TITLE
[users] 회원 기능 구현 - AuthServiceImplTest 수정 #321

### DIFF
--- a/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/auth/application/service/AuthServiceImplTest.java
+++ b/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/auth/application/service/AuthServiceImplTest.java
@@ -116,21 +116,20 @@ public class AuthServiceImplTest {
 
     Staff staff = Staff.builder().loginId(username).build();
 
-    Mockito.doNothing().when(jwtTokenProvider).validateToken(oldRefreshToken);
+    Mockito.when(jwtTokenProvider.validateToken(oldRefreshToken)).thenReturn(true);
     Mockito.when(jwtTokenProvider.getUsernameFromJWT(oldRefreshToken)).thenReturn(username);
     Mockito.when(valueOperations.get(redisKey)).thenReturn(oldRefreshToken);
     Mockito.when(userRepository.findStaffByLoginId(username)).thenReturn(Optional.of(staff));
     Mockito.when(jwtTokenProvider.createToken(username)).thenReturn(newAccessToken);
     Mockito.when(jwtTokenProvider.createRefreshToken(username)).thenReturn(newRefreshToken);
     Mockito.when(jwtTokenProvider.getRefreshExpiration()).thenReturn(600000L); // 10분
-
     // when
     TokenResponse response = authService.refreshToken(oldRefreshToken);
 
     // then
     assertEquals(newAccessToken, response.getAccessToken());
     assertEquals(newRefreshToken, response.getRefreshToken());
-    verify(valueOperations).set(redisKey, newRefreshToken, 600000L, TimeUnit.MILLISECONDS);
+    Mockito.verify(valueOperations).set(redisKey, newRefreshToken, 600000L, TimeUnit.MILLISECONDS);
   }
 
   @Test
@@ -140,7 +139,7 @@ public class AuthServiceImplTest {
     String username = "userX";
     String redisKey = "RT:" + username;
 
-    Mockito.doNothing().when(jwtTokenProvider).validateToken(token);
+    Mockito.when(jwtTokenProvider.validateToken(token)).thenReturn(true);
     Mockito.when(jwtTokenProvider.getUsernameFromJWT(token)).thenReturn(username);
     Mockito.when(valueOperations.get(redisKey)).thenReturn(null);
 
@@ -154,7 +153,7 @@ public class AuthServiceImplTest {
     String username = "userX";
     String redisKey = "RT:" + username;
 
-    Mockito.doNothing().when(jwtTokenProvider).validateToken(token);
+    Mockito.when(jwtTokenProvider.validateToken(token)).thenReturn(true);
     Mockito.when(jwtTokenProvider.getUsernameFromJWT(token)).thenReturn(username);
     Mockito.when(valueOperations.get(redisKey)).thenReturn("tokenB"); // 불일치
 
@@ -168,7 +167,7 @@ public class AuthServiceImplTest {
     String username = "ghost";
     String redisKey = "RT:" + username;
 
-    Mockito.doNothing().when(jwtTokenProvider).validateToken(token);
+    Mockito.when(jwtTokenProvider.validateToken(token)).thenReturn(true);
     Mockito.when(jwtTokenProvider.getUsernameFromJWT(token)).thenReturn(username);
     Mockito.when(valueOperations.get(redisKey)).thenReturn(token);
     Mockito.when(userRepository.findStaffByLoginId(username)).thenReturn(Optional.empty());


### PR DESCRIPTION
### 개발 영역

Backend

### 🐛 문제 설명

- RefreshToken 재발급 테스트 시 return 타입에 맞지 않는  Mockito 사용으로 통과 실패. 

### 🔄 문제 재연 방법

1. AuthServiceImplTest 메소드 단위 테스트 실행

### ✅ 수정 체크리스트

- [x] 문제 원인 파악 완료
- [x] 수정 완료
- [x] 테스트 완료
- [x] 문서 업데이트

## 🔍 이슈 체크리스트 상태
⚠️ **0/4 완료** (미완료 항목 있음)


## 🔗 관련 이슈
Closes #321

---

## 📋 비고

<!-- PR에 관련하여 하고 싶은 말이 있다면 아래에 남겨주세요.-->

<!-- 이슈 번호를 PR 타이틀에 포함하면 (#123) 해당 이슈의 내용, 체크리스트 상태, Closes 키워드가 자동으로 여기에 복사됩니다 -->
<!-- 이슈 내용, 체크리스트 상태, 관련 이슈 정보가 자동으로 여기에 추가됩니다 -->
