### PR TITLE
[sales] 매출 기능 구현 - 회원권 매출 환불 기능 구현 #356

### DIFF
--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/common/exception/ErrorCode.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/common/exception/ErrorCode.java
@@ -121,6 +121,7 @@ public enum ErrorCode implements ErrorCodeType {
   SALES_PAYMENTMETHOD_REQUIRED("90004", "결제수단을 입력해주세요.", HttpStatus.BAD_REQUEST),
   SALES_PAYMENTSAMOUNT_REQUIRED("90005", "결제금액을 입력해주세요.", HttpStatus.BAD_REQUEST),
   SALES_NOT_FOUND("90006", "매출을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  SALES_ALREADY_REFUNDED("90007", "이미 환불된 매출입니다.", HttpStatus.BAD_REQUEST),
   ;
 
   private final String code;

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/sales/command/application/controller/SalesCommandController.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/sales/command/application/controller/SalesCommandController.java
@@ -1,0 +1,32 @@
+package com.deveagles.be15_deveagles_be.features.sales.command.application.controller;
+
+import com.deveagles.be15_deveagles_be.common.dto.ApiResponse;
+import com.deveagles.be15_deveagles_be.features.sales.command.application.service.SalesCommandService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "매출", description = "매출 API")
+@RestController
+@RequestMapping("sales")
+@RequiredArgsConstructor
+@Validated
+@Slf4j
+public class SalesCommandController {
+
+  private final SalesCommandService salesCommandService;
+
+  @Operation(summary = "매출 환불", description = "해당 salesId의 매출을 환불 처리합니다.")
+  @PostMapping("/refund/{salesId}")
+  public ResponseEntity<ApiResponse<Void>> refundSales(@PathVariable Long salesId) {
+    salesCommandService.refundSales(salesId);
+    return ResponseEntity.ok(ApiResponse.success(null));
+  }
+}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/sales/command/application/service/SalesCommandService.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/sales/command/application/service/SalesCommandService.java
@@ -1,0 +1,6 @@
+package com.deveagles.be15_deveagles_be.features.sales.command.application.service;
+
+public interface SalesCommandService {
+
+  void refundSales(Long salesId);
+}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/sales/command/application/service/impl/SalesCommandServiceImpl.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/sales/command/application/service/impl/SalesCommandServiceImpl.java
@@ -1,0 +1,32 @@
+package com.deveagles.be15_deveagles_be.features.sales.command.application.service.impl;
+
+import com.deveagles.be15_deveagles_be.common.exception.BusinessException;
+import com.deveagles.be15_deveagles_be.common.exception.ErrorCode;
+import com.deveagles.be15_deveagles_be.features.sales.command.application.service.SalesCommandService;
+import com.deveagles.be15_deveagles_be.features.sales.command.domain.aggregate.Sales;
+import com.deveagles.be15_deveagles_be.features.sales.command.domain.repository.SalesRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SalesCommandServiceImpl implements SalesCommandService {
+
+  private final SalesRepository salesRepository;
+
+  @Transactional
+  @Override
+  public void refundSales(Long salesId) {
+    Sales sales =
+        salesRepository
+            .findById(salesId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.SALES_NOT_FOUND));
+
+    if (sales.isRefunded()) {
+      throw new BusinessException(ErrorCode.SALES_ALREADY_REFUNDED);
+    }
+
+    sales.setRefunded(true);
+  }
+}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/sales/command/domain/aggregate/Sales.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/sales/command/domain/aggregate/Sales.java
@@ -81,4 +81,12 @@ public class Sales {
     this.salesMemo = salesMemo;
     this.salesDate = salesDate;
   }
+
+  public Boolean isRefunded() {
+    return isRefunded;
+  }
+
+  public void setRefunded(boolean isRefunded) {
+    this.isRefunded = isRefunded;
+  }
 }

--- a/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/sales/command/application/service/impl/SalesCommandServiceImplTest.java
+++ b/be15_DevEagles_BE/src/test/java/com/deveagles/be15_deveagles_be/features/sales/command/application/service/impl/SalesCommandServiceImplTest.java
@@ -1,0 +1,72 @@
+package com.deveagles.be15_deveagles_be.features.sales.command.application.service.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.deveagles.be15_deveagles_be.common.exception.BusinessException;
+import com.deveagles.be15_deveagles_be.common.exception.ErrorCode;
+import com.deveagles.be15_deveagles_be.features.sales.command.domain.aggregate.Sales;
+import com.deveagles.be15_deveagles_be.features.sales.command.domain.repository.SalesRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class SalesCommandServiceImplTest {
+
+  @Mock private SalesRepository salesRepository;
+
+  @InjectMocks private SalesCommandServiceImpl salesCommandService;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  @DisplayName("성공: 매출 환불 처리")
+  void refundSales_success() {
+    // given
+    Long salesId = 1L;
+    Sales sales = mock(Sales.class);
+    when(sales.isRefunded()).thenReturn(false);
+    when(salesRepository.findById(salesId)).thenReturn(Optional.of(sales));
+
+    // when
+    salesCommandService.refundSales(salesId);
+
+    // then
+    verify(sales).setRefunded(true);
+  }
+
+  @Test
+  @DisplayName("예외: 존재하지 않는 매출 ID")
+  void refundSales_salesNotFound() {
+    // given
+    Long salesId = 1L;
+    when(salesRepository.findById(salesId)).thenReturn(Optional.empty());
+
+    // when & then
+    BusinessException exception =
+        assertThrows(BusinessException.class, () -> salesCommandService.refundSales(salesId));
+    assertEquals(ErrorCode.SALES_NOT_FOUND, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("예외: 이미 환불된 매출")
+  void refundSales_alreadyRefunded() {
+    // given
+    Long salesId = 1L;
+    Sales sales = mock(Sales.class);
+    when(sales.isRefunded()).thenReturn(true);
+    when(salesRepository.findById(salesId)).thenReturn(Optional.of(sales));
+
+    // when & then
+    BusinessException exception =
+        assertThrows(BusinessException.class, () -> salesCommandService.refundSales(salesId));
+    assertEquals(ErrorCode.SALES_ALREADY_REFUNDED, exception.getErrorCode());
+  }
+}


### PR DESCRIPTION
### 개발 영역

Backend

### 📋 기능 설명

- 회원권 매출 환불 기능 구현

### ✅ 개발 체크리스트

- [x] 요구사항 분석 완료
- [x] 구현 완료
- [x] 단위 테스트 작성
- [x] 문서 업데이트

## 🔍 이슈 체크리스트 상태
✅ **4/4 완료** (모든 항목 완료!)


## 🔗 관련 이슈
Closes #356

---

- 회원권 매출 환불 기능 구현

## 📋 비고

<!-- PR에 관련하여 하고 싶은 말이 있다면 아래에 남겨주세요.-->

<!-- 이슈 번호를 PR 타이틀에 포함하면 (#123) 해당 이슈의 내용, 체크리스트 상태, Closes 키워드가 자동으로 여기에 복사됩니다 -->
<!-- 이슈 내용, 체크리스트 상태, 관련 이슈 정보가 자동으로 여기에 추가됩니다 -->
