### PR TITLE
[staffs] 직원 기능 수정 - 직원 목록 조회 시 민감 정보 제외 #405

### DIFF
--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/users/query/application/dto/response/StaffListInfo.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/users/query/application/dto/response/StaffListInfo.java
@@ -1,0 +1,17 @@
+package com.deveagles.be15_deveagles_be.features.users.query.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StaffListInfo {
+
+  private Long staffId;
+  private String staffName;
+  private String loginId;
+  private String phoneNumber;
+  private String grade;
+  private String colorCode;
+  private boolean isWorking;
+}

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/users/query/application/dto/response/StaffsListResponse.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/users/query/application/dto/response/StaffsListResponse.java
@@ -1,7 +1,6 @@
 package com.deveagles.be15_deveagles_be.features.users.query.application.dto.response;
 
 import com.deveagles.be15_deveagles_be.common.dto.Pagination;
-import com.deveagles.be15_deveagles_be.features.users.command.domain.aggregate.Staff;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,6 +9,6 @@ import lombok.Getter;
 @Builder
 public class StaffsListResponse {
 
-  private List<Staff> staffList;
+  private List<StaffListInfo> staffList;
   private Pagination pagination;
 }

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/users/query/application/service/StaffQueryServiceImpl.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/users/query/application/service/StaffQueryServiceImpl.java
@@ -1,7 +1,7 @@
 package com.deveagles.be15_deveagles_be.features.users.query.application.service;
 
 import com.deveagles.be15_deveagles_be.common.dto.Pagination;
-import com.deveagles.be15_deveagles_be.features.users.command.domain.aggregate.Staff;
+import com.deveagles.be15_deveagles_be.features.users.query.application.dto.response.StaffListInfo;
 import com.deveagles.be15_deveagles_be.features.users.query.application.dto.response.StaffsListResponse;
 import com.deveagles.be15_deveagles_be.features.users.query.infraStrucure.repository.StaffQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +24,8 @@ public class StaffQueryServiceImpl implements StaffQueryService {
       Long shopId, int size, int page, String keyword, Boolean isActive) {
 
     Pageable pageable = PageRequest.of(page - 1, size, Sort.by("staffId").descending());
-    Page<Staff> staffPage = staffQueryRepository.searchStaffs(shopId, keyword, isActive, pageable);
+    Page<StaffListInfo> staffPage =
+        staffQueryRepository.searchStaffs(shopId, keyword, isActive, pageable);
 
     return StaffsListResponse.builder()
         .staffList(staffPage.getContent())

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/users/query/infraStrucure/repository/StaffQueryRepository.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/users/query/infraStrucure/repository/StaffQueryRepository.java
@@ -1,10 +1,11 @@
 package com.deveagles.be15_deveagles_be.features.users.query.infraStrucure.repository;
 
-import com.deveagles.be15_deveagles_be.features.users.command.domain.aggregate.Staff;
+import com.deveagles.be15_deveagles_be.features.users.query.application.dto.response.StaffListInfo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface StaffQueryRepository {
 
-  Page<Staff> searchStaffs(Long shopId, String keyword, Boolean isActive, Pageable pageable);
+  Page<StaffListInfo> searchStaffs(
+      Long shopId, String keyword, Boolean isActive, Pageable pageable);
 }

--- a/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/users/query/infraStrucure/repository/StaffQueryRepositoryImpl.java
+++ b/be15_DevEagles_BE/src/main/java/com/deveagles/be15_deveagles_be/features/users/query/infraStrucure/repository/StaffQueryRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.deveagles.be15_deveagles_be.features.users.query.infraStrucure.repos
 import static com.deveagles.be15_deveagles_be.features.users.command.domain.aggregate.QStaff.staff;
 
 import com.deveagles.be15_deveagles_be.features.users.command.domain.aggregate.Staff;
+import com.deveagles.be15_deveagles_be.features.users.query.application.dto.response.StaffListInfo;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -19,7 +20,7 @@ public class StaffQueryRepositoryImpl implements StaffQueryRepository {
   private final JPAQueryFactory queryFactory;
 
   @Override
-  public Page<Staff> searchStaffs(
+  public Page<StaffListInfo> searchStaffs(
       Long shopId, String keyword, Boolean isActive, Pageable pageable) {
     List<Staff> content =
         queryFactory
@@ -30,6 +31,21 @@ public class StaffQueryRepositoryImpl implements StaffQueryRepository {
             .orderBy(staff.staffId.desc())
             .fetch();
 
+    List<StaffListInfo> response =
+        content.stream()
+            .map(
+                staff ->
+                    StaffListInfo.builder()
+                        .staffId(staff.getStaffId())
+                        .staffName(staff.getStaffName())
+                        .loginId(staff.getLoginId())
+                        .phoneNumber(staff.getPhoneNumber())
+                        .grade(staff.getGrade())
+                        .isWorking(staff.getLeftDate() == null)
+                        .colorCode(staff.getColorCode())
+                        .build())
+            .toList();
+
     // count
     long total =
         queryFactory
@@ -38,7 +54,7 @@ public class StaffQueryRepositoryImpl implements StaffQueryRepository {
             .where(staff.shopId.eq(shopId), keywordContains(keyword), isActiveEq(isActive))
             .fetchOne();
 
-    return new PageImpl<>(content, pageable, total);
+    return new PageImpl<>(response, pageable, total);
   }
 
   private BooleanExpression keywordContains(String keyword) {

--- a/be15_DevEagles_FE/src/features/staffs/views/StaffListView.vue
+++ b/be15_DevEagles_FE/src/features/staffs/views/StaffListView.vue
@@ -21,7 +21,11 @@
 
     <!-- 테이블 -->
     <div class="table-wrapper">
+      <div v-if="loading" class="table-loading-overlay">
+        <BaseLoading text="직원 목록을 조회하는 중입니다..." />
+      </div>
       <BaseTable
+        v-if="!loading"
         :columns="columns"
         :data="staffList"
         :hover="true"
@@ -70,6 +74,7 @@
   import BaseToast from '@/components/common/BaseToast.vue';
   import BaseBadge from '@/components/common/BaseBadge.vue';
   import { debounce } from 'chart.js/helpers';
+  import BaseLoading from '@/components/common/BaseLoading.vue';
 
   const router = useRouter();
   const toastRef = ref();
@@ -80,6 +85,7 @@
   const totalCount = ref(0);
   const searchText = ref('');
   const onlyActive = ref(false);
+  const loading = ref(false);
 
   const columns = [
     { key: 'staffName', title: '이름', width: '200px' },
@@ -96,6 +102,7 @@
   };
 
   const fetchStaff = async () => {
+    loading.value = true;
     try {
       const res = await getStaff({
         page: page.value,
@@ -106,6 +113,7 @@
 
       staffList.value = res.data.data.staffList;
       totalCount.value = res.data.data.pagination.totalItems;
+      loading.value = false;
     } catch (err) {
       toastRef.value?.error?.('직원 목록 조회에 실패했습니다.');
     }


### PR DESCRIPTION
### 개발 영역

Backend

### 🐛 문제 설명

<img width="563" height="283" alt="Image" src="https://github.com/user-attachments/assets/f536edb8-2af1-4824-bb0c-f60b1f42d1e7" />
- 현재 불필요한 민감 정보까지 모두 조회됨(암호 포함)
- 응답값 수정 요청

### 🔄 문제 재연 방법

GET staffs api 호출

### ✅ 수정 체크리스트

- [ ] 문제 원인 파악 완료
- [ ] 수정 완료
- [ ] 테스트 완료
- [ ] 문서 업데이트

## 🔍 이슈 체크리스트 상태
⚠️ **0/4 완료** (미완료 항목 있음)


## 🔗 관련 이슈
Closes #405

---

## 📋 비고

<!-- PR에 관련하여 하고 싶은 말이 있다면 아래에 남겨주세요.-->

<!-- 이슈 번호를 PR 타이틀에 포함하면 (#123) 해당 이슈의 내용, 체크리스트 상태, Closes 키워드가 자동으로 여기에 복사됩니다 -->
<!-- 이슈 내용, 체크리스트 상태, 관련 이슈 정보가 자동으로 여기에 추가됩니다 -->
